### PR TITLE
move reload hook to cronjob

### DIFF
--- a/pyinfra_acmetool/__init__.py
+++ b/pyinfra_acmetool/__init__.py
@@ -3,31 +3,21 @@ import importlib.resources
 from pyinfra.operations import apt, files, systemd, server
 
 
-def deploy_acmetool(nginx_hook=False, email="", domains=[]):
+def deploy_acmetool(reload_hook="", email="", domains=[]):
     """Deploy acmetool."""
     apt.packages(
         name="Install acmetool",
         packages=["acmetool"],
     )
 
-    files.put(
-        src=importlib.resources.files(__package__).joinpath("acmetool.cron").open("rb"),
+    files.template(
+        src=importlib.resources.files(__package__).joinpath("acmetool.cron.j2").open("rb"),
         dest="/etc/cron.d/acmetool",
         user="root",
         group="root",
         mode="644",
+        reload_hook=reload_hook,
     )
-
-    if nginx_hook:
-        files.put(
-            src=importlib.resources.files(__package__)
-            .joinpath("acmetool.hook")
-            .open("rb"),
-            dest="/usr/lib/acme/hooks/nginx",
-            user="root",
-            group="root",
-            mode="744",
-        )
 
     files.template(
         src=importlib.resources.files(__package__).joinpath("response-file.yaml.j2"),

--- a/pyinfra_acmetool/__init__.py
+++ b/pyinfra_acmetool/__init__.py
@@ -11,7 +11,9 @@ def deploy_acmetool(reload_hook="", email="", domains=[]):
     )
 
     files.template(
-        src=importlib.resources.files(__package__).joinpath("acmetool.cron.j2").open("rb"),
+        src=importlib.resources.files(__package__)
+        .joinpath("acmetool.cron.j2")
+        .open("rb"),
         dest="/etc/cron.d/acmetool",
         user="root",
         group="root",

--- a/pyinfra_acmetool/__init__.py
+++ b/pyinfra_acmetool/__init__.py
@@ -11,9 +11,7 @@ def deploy_acmetool(reload_hook="", email="", domains=[]):
     )
 
     files.template(
-        src=importlib.resources.files(__package__)
-        .joinpath("acmetool.cron.j2")
-        .open("rb"),
+        src=importlib.resources.files(__package__) / "acmetool.cron.j2",
         dest="/etc/cron.d/acmetool",
         user="root",
         group="root",

--- a/pyinfra_acmetool/acmetool.cron.j2
+++ b/pyinfra_acmetool/acmetool.cron.j2
@@ -1,4 +1,4 @@
 SHELL=/bin/sh
 PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin
 MAILTO=root
-20 16 * * * root /usr/bin/acmetool --batch reconcile && systemctl reload nginx
+20 16 * * * root /usr/bin/acmetool --batch reconcile && {{ reload_hook }}

--- a/pyinfra_acmetool/acmetool.hook
+++ b/pyinfra_acmetool/acmetool.hook
@@ -1,5 +1,0 @@
-#!/bin/sh
-set -e
-EVENT_NAME="$1"
-[ "$EVENT_NAME" = "live-updated" ] || exit 42
-systemctl restart nginx.service

--- a/tox.ini
+++ b/tox.ini
@@ -10,4 +10,4 @@ deps =
   black
 commands =
   black --quiet --check --diff pyinfra_acmetool
-  ruff pyinfra_acmetool
+  ruff check pyinfra_acmetool


### PR DESCRIPTION
The acme hooks in `/usr/lib/acme` prove to be broken again and again. Let's do it in the cronjob which executes the `acmetook reconcile` in most cases anyway.