### PR TITLE
manage desired.yaml files explicitely, enable requesting TLS certs later

### DIFF
--- a/pyinfra_acmetool/__init__.py
+++ b/pyinfra_acmetool/__init__.py
@@ -1,9 +1,11 @@
 import importlib.resources
 
+from pyinfra import host
+from pyinfra.facts.files import FindFiles
 from pyinfra.operations import apt, files, systemd, server
 
 
-def deploy_acmetool(reload_hook="", email="", domains=[]):
+def deploy_acmetool(reload_hook="", email="", domains=[], request_later=False):
     """Deploy acmetool."""
     apt.packages(
         name="Install acmetool",
@@ -45,8 +47,24 @@ def deploy_acmetool(reload_hook="", email="", domains=[]):
         restarted=service_file.changed,
     )
 
-    for domain in domains:
+    old_desired_files = host.get_fact(
+        FindFiles, path="/var/lib/acme/desired", fname=f"{domains[0]}-*"
+    )
+    for file in old_desired_files:
+        files.file(
+            path=file,
+            present=False,
+        )
+    files.template(
+        src=importlib.resources.files(__package__).joinpath("desired.yaml.j2"),
+        dest=f"/var/lib/acme/desired/{domains[0]}",
+        user="root",
+        group="root",
+        mode="644",
+        domains=domains,
+    )
+    if not request_later:
         server.shell(
-            name=f"Request certificate for {domain}",
-            commands=[f"acmetool want {domain}"],
+            name=f"Request certificate for: {' '.join(domains)}",
+            commands=["acmetool --batch --xlog.severity=debug reconcile"],
         )

--- a/pyinfra_acmetool/desired.yaml.j2
+++ b/pyinfra_acmetool/desired.yaml.j2
@@ -1,0 +1,6 @@
+satisfy:
+  names:
+{%- for domain in domains %}
+  - {{ domain }}
+{%- endfor %}
+


### PR DESCRIPTION
This brings https://github.com/chatmail/relay/commit/df21076e9bf4877567bf10bdf50ace7f6a1c390e to our internal deployments, with a minimum of non-idempotent pyinfra operations :)